### PR TITLE
Add timeout duration to initialize slick method

### DIFF
--- a/dist/slick.js
+++ b/dist/slick.js
@@ -140,7 +140,7 @@ angular.module('slick', []).directive('slick', [
                 return slider.slick('slickGoTo', newVal);
               }
             });
-          });
+          }, 500);
         };
         if (scope.initOnload) {
           isInitialized = false;


### PR DESCRIPTION
This will allow angular slick to calculate container size especially for dynamic content such as mdDialog.